### PR TITLE
Removed the class name icon from the wysiwyg editor

### DIFF
--- a/fancypages/templates/fancypages/partials/wysihtml5_toolbar.html
+++ b/fancypages/templates/fancypages/partials/wysihtml5_toolbar.html
@@ -36,7 +36,7 @@
                     <i class="glyphicon-list-alt"></i>
                 </a>
 
-                <a data-wysihtml5-action="change_view" href="javascript:;" class='fp-btn' unselectable="on"><i class="icon-text">html</i></a>
+                <a data-wysihtml5-action="change_view" href="javascript:;" class='fp-btn' unselectable="on">html</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Removed the class name icon from the wysiwyg editor - possible conflict with other uses of class name icon.
