### PR TITLE
Fix context names for pages in dashboard views/templates

### DIFF
--- a/fancypages/dashboard/views.py
+++ b/fancypages/dashboard/views.py
@@ -19,7 +19,7 @@ OrderedContainer = get_model('fancypages', 'OrderedContainer')
 
 class PageListView(generic.ListView):
     model = FancyPage
-    context_object_name = 'page_list'
+    context_object_name = 'fancypage_list'
     template_name = "fancypages/dashboard/page_list.html"
 
     def get_queryset(self, queryset=None):
@@ -48,7 +48,7 @@ class PageCreateView(generic.CreateView):
 class PageUpdateView(generic.UpdateView):
     model = FancyPage
     form_class = forms.PageNodeForm
-    context_object_name = 'page'
+    context_object_name = 'fancypage'
     template_name = "fancypages/dashboard/page_update.html"
 
     def get_context_data(self, **kwargs):
@@ -62,6 +62,7 @@ class PageUpdateView(generic.UpdateView):
 
 class PageDeleteView(generic.DeleteView):
     model = FancyPage
+    context_object_name = 'fancypage'
     template_name = "fancypages/dashboard/page_delete.html"
 
     def get_success_url(self):

--- a/fancypages/templates/fancypages/dashboard/page_delete.html
+++ b/fancypages/templates/fancypages/dashboard/page_delete.html
@@ -18,7 +18,7 @@
         <span class="divider">/</span>
     </li>
     <li>
-        <a href="{% url "fp-dashboard:page-update" page.pk %}">{{ page.title }}</a>
+        <a href="{% url "fp-dashboard:page-update" page.pk %}">{{ fancypage.title }}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{% trans "Delete?" %}</li>

--- a/fancypages/templates/fancypages/dashboard/page_list.html
+++ b/fancypages/templates/fancypages/dashboard/page_list.html
@@ -21,13 +21,13 @@
 {% endblock header %}
 
 {% block dashboard_content %}
-    {% if page_list|length %}
+    {% if fancypage_list|length %}
     <form action="." method="post">
         {% csrf_token %}
 
-        {% if page_list|length %}
+        {% if fancypage_list|length %}
             <ol id="pages-sortable" class="fp-page-tree">
-                {% include "fancypages/dashboard/partials/page_list_item.html" with page_list=page_list %}
+                {% include "fancypages/dashboard/partials/page_list_item.html" with fancypage_list=fancypage_list %}
             </ol>
         {% else %}
             <p>{% trans "No pages found." %}</p>

--- a/fancypages/templates/fancypages/dashboard/page_update.html
+++ b/fancypages/templates/fancypages/dashboard/page_update.html
@@ -19,7 +19,7 @@
         <span class="divider">/</span>
     </li>
     <li class="active">
-        {% if page.pk %}{{ page.title }}{% else %}Create new page{% endif %}
+        {% if page.pk %}{{ fancypage.title }}{% else %}Create new page{% endif %}
     </li>
 </ul>
 {% endblock %}

--- a/fancypages/templates/fancypages/dashboard/partials/page_list_item.html
+++ b/fancypages/templates/fancypages/dashboard/partials/page_list_item.html
@@ -2,41 +2,40 @@
 {% load fp_block_tags %}
 {% load url from future %}
 
-{% for page in page_list %}
-<li id="page-{{ page.id }}" class="sortable {% if forloop.last %}last{% endif %}" data-page-id="{{ page.id }}">
+{% for fancypage in fancypage_list %}
+<li id="page-{{ fancypage.id }}" class="sortable {% if forloop.last %}last{% endif %}" data-page-id="{{ fancypage.id }}">
     <div class="row-fluid" >
         <h5 class="span10">
-            {% if page.numchild %}
-            <a href="#" data-toggle="collapse" data-target="#{{ page.id }}-tree" class="collapsed"><i class="icon-caret-down"></i></a>
+            {% if fancypage.numchild %}
+            <a href="#" data-toggle="collapse" data-target="#{{ fancypage.id }}-tree" class="collapsed"><i class="icon-caret-down"></i></a>
             {% endif %}
-            <a href="#" data-toggle="collapse" data-target="#{{ page.id }}-actions"><i class="icon-file icon-large"></i> {{ page.name }}</a>
+            <a href="#" data-toggle="collapse" data-target="#{{ fancypage.id }}-actions"><i class="icon-file icon-large"></i> {{ fancypage.name }}</a>
         </h5>
 
         <div class="span2">
-            {% if page.is_visible %}
+            {% if fancypage.is_visible %}
             <span class="label label-success">{% trans "visible" %}</span>
             {% else %}
             <span class="label label-danger">{% trans "not visible" %}</span>
             {% endif %}
-            <span class="label">{{ page.status|capfirst }}</span>
+            <span class="label">{{ fancypage.status|capfirst }}</span>
         </div>
     </div>
 
-    <div class="collapse" id="{{ page.id }}-actions">
+    <div class="collapse" id="{{ fancypage.id }}-actions">
         <div class="row-actions">
-            <!-- <a href="#" data-toggle="collapse" data-target="#{{ page.id }}-actions"><i class="icon-caret-up"></i></a> -->
-            <a class="btn btn-small" href="{{ page.get_absolute_url }}">{% trans "View page" %}</a>
-            <a class="btn btn-small btn-success" href="{% url "fp-dashboard:child-page-create" parent_pk=page.id %}">{% trans "Add child page" %}</a>
-            <a class="btn btn-small btn-danger" href="{% url "fp-dashboard:page-delete" page.id %}">{% trans "Delete" %}</a>
-            <a class="btn btn-small" href="{% url "fp-dashboard:page-update" page.id %}">{% trans "Edit page settings" %}</a>
-            links to <a href="{{ page.get_absolute_url }}"><i class="icon-link"></i> {{ page.get_absolute_url }}</a>
+            <a class="btn btn-small" href="{{ fancypage.get_absolute_url }}">{% trans "View page" %}</a>
+            <a class="btn btn-small btn-success" href="{% url "fp-dashboard:child-page-create" parent_pk=fancypage.id %}">{% trans "Add child page" %}</a>
+            <a class="btn btn-small btn-danger" href="{% url "fp-dashboard:page-delete" fancypage.id %}">{% trans "Delete" %}</a>
+            <a class="btn btn-small" href="{% url "fp-dashboard:page-update" fancypage.id %}">{% trans "Edit page settings" %}</a>
+            links to <a href="{{ fancypage.get_absolute_url }}"><i class="icon-link"></i> {{ fancypage.get_absolute_url }}</a>
         </div>
     </div>
 
-    {% if page.node.numchild %}
-    <ol id="{{ page.id }}-tree" class="collapse">
+    {% if fancypage.node.numchild %}
+    <ol id="{{ fancypage.id }}-tree" class="collapse">
         {% with filename="fancypages/dashboard/partials/page_list_item.html" %}
-        {% include filename with page_list=page.node.get_children %}
+        {% include filename with fancypage_list=fancypage.node.get_children %}
         {% endwith %}
     </ol>
     {% endif %}

--- a/fancypages/templates/fancypages/dashboard/partials/page_select_link.html
+++ b/fancypages/templates/fancypages/dashboard/partials/page_select_link.html
@@ -23,6 +23,4 @@
         </ol>
         {% endif %}
     </li>
-    
-    
 {% endfor %}


### PR DESCRIPTION
Fixes the issue pointed out by @rosner in #16 not setting `context_object_name` consistently. I've renamed the context variable to `fancypage` to avoid clashes in the context with other `page` objects. This should only be an issue with list views using Django's pagination object but for consistency I'd suggest using `fancypage` across the board.
