### PR TITLE
Using Oscar's load_class to get ProductCategoryView

### DIFF
--- a/fancypages/contrib/oscar_fancypages/views.py
+++ b/fancypages/contrib/oscar_fancypages/views.py
@@ -1,6 +1,9 @@
-from oscar.apps.catalogue.views import ProductCategoryView
+from oscar.core.loading import load_class
 
 from . import mixins
+
+
+ProductCategoryView = load_class('catalogue.views', 'ProductCategoryView')
 
 
 class FancyPageDetailView(mixins.OscarFancyPageMixin, ProductCategoryView):


### PR DESCRIPTION
The Oscar contrib views hard codes the import of ProductCategoryView.
This proves problematic when attempting to override the view in a
local project.

This change uses oscar.core.loading.get_class to obtain the view
instead.
