### PR TITLE
Quote fancypages.urls in url pattern

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -153,7 +153,7 @@ go through these steps first. After you have completed them, follow the
 
     urlpatterns = patterns('',
         ...
-        url(r'^', include(fancypages.urls)),
+        url(r'^', include('fancypages.urls')),
     )
 
 5. Fancypages requires several default settings to be added. To make sure


### PR DESCRIPTION
Since you're not importing fancypages.urls we need to wrap it in quotes so Django will import it.
